### PR TITLE
refactor: remove unused useEffect for theme application in StyleExamp…

### DIFF
--- a/example/src/components/StyleExample.tsx
+++ b/example/src/components/StyleExample.tsx
@@ -242,11 +242,6 @@ export const StyleExample: React.FC<StyleExampleProps> = ({
     }
   };
 
-  useEffect(() => {
-    // Note: Theme is now applied automatically by App.tsx on startup
-    // This component only handles manual theme switching
-  }, []);
-
   return (
     <ScrollView style={styles.container}>
       <View style={styles.header}>


### PR DESCRIPTION

This pull request makes a small change to the `StyleExample` component by removing an unused `useEffect` hook that contained a comment about theme application. This cleanup simplifies the code and reflects that theme handling is now managed elsewhere (`[example/src/components/StyleExample.tsxL245-L249](diffhunk://#diff-5e6e7ae83ff89fb841fa8a3b60d200b4f1356c92c57310e085e3c47aa8652009L245-L249)`).